### PR TITLE
WIP add dependency injection and mocks to tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,12 @@ dependencies {
     compile "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
     compile "org.glassfish.jaxb:jaxb-runtime:2.3.2"
     compile 'com.uchuhimo:konf:0.21.0'
+    compile 'dev.misfitlabs.kotlinguice4:kotlin-guice:1.4.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
-    testCompile "org.mockito:mockito-core:1.+"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+
 }
 
 compileKotlin {

--- a/src/main/kotlin/it/polpetta/cli/Login.kt
+++ b/src/main/kotlin/it/polpetta/cli/Login.kt
@@ -22,23 +22,25 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.prompt
+import com.google.inject.Inject
 import com.uchuhimo.konf.Config
 import com.uchuhimo.konf.source.toml.toToml
 import it.polpetta.config.Auth
 import it.polpetta.config.Resources
-import it.polpetta.utils.Jenkins
+import it.polpetta.utils.JenkinsSession
 import it.polpetta.utils.printErrln
 import it.polpetta.utils.pwd
 import java.nio.file.Path
 import kotlin.system.exitProcess
 
-class Login : CliktCommand(help = "Login to the remote Jenkins instance") {
+class Login @Inject constructor(private val jenkinsSession: JenkinsSession) :
+    CliktCommand(help = "Login to the remote Jenkins instance") {
     private val url: String by argument("server_url", "Jenkins server URL")
     private val username: String? by option("-u", "--username", help = "Jenkins username").prompt("Username")
     private val password: String? by option("-p", "--password", help = "Jenkins password/auth token").prompt("Password")
 
     override fun run() {
-        val jenkins = Jenkins.with(url, username, password)
+        val jenkins = jenkinsSession.with(url, username, password)
         val authConfig = Config { addSpec(Auth) }
         val jenkinsVersion = jenkins.api().systemApi().systemInfo().jenkinsVersion()
 

--- a/src/main/kotlin/it/polpetta/cli/Status.kt
+++ b/src/main/kotlin/it/polpetta/cli/Status.kt
@@ -20,19 +20,23 @@ package it.polpetta.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
-import it.polpetta.utils.Jenkins
+import com.google.inject.Inject
+import it.polpetta.utils.JenkinsSession
 import it.polpetta.utils.printErrln
 import kotlin.system.exitProcess
 
-class Status : CliktCommand(help = "Show the working tree status") {
+class Status @Inject constructor(private val jenkinsSession: JenkinsSession) :
+    CliktCommand(help = "Show the working tree status") {
+
     private val jobName: String by argument("job_name", "Name of the Job to display")
+
     override fun run() {
-        val jenkinsSession = Jenkins.retrieveSession {
+        val session = jenkinsSession.retrieveSession {
             printErrln("ABORT: No Jenkins instance to connect to")
             exitProcess(1)
         }!!
 
-        val jobInfo = jenkinsSession.api().jobsApi().jobInfo(null, jobName)
+        val jobInfo = session.api().jobsApi().jobInfo(null, jobName)
         val lastBuild = jobInfo.lastBuild()
         val prettyIsBuilding = if(lastBuild.building()) {
             "building"

--- a/src/main/kotlin/it/polpetta/cli/Version.kt
+++ b/src/main/kotlin/it/polpetta/cli/Version.kt
@@ -19,15 +19,14 @@
 package it.polpetta.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
-import it.polpetta.config.Resources
+import com.google.inject.Inject
 import it.polpetta.config.VersionInfo
-import it.polpetta.utils.Jenkins
-import it.polpetta.utils.printErrln
-import kotlin.system.exitProcess
+import it.polpetta.utils.JenkinsSession
 
-class Version: CliktCommand(help = "Prints information about the cli and the server, if logged in") {
+class Version @Inject constructor(private val jenkinsSession: JenkinsSession) :
+    CliktCommand(help = "Prints information about the cli and the server, if logged in") {
     override fun run() {
-        val jenkinsSession = Jenkins.retrieveSession()
+        val jenkinsSession = jenkinsSession.retrieveSession()
 
         if (jenkinsSession != null && jenkinsSession.api().systemApi().systemInfo().jenkinsVersion() != "-1")
         {

--- a/src/main/kotlin/it/polpetta/main.kt
+++ b/src/main/kotlin/it/polpetta/main.kt
@@ -20,20 +20,25 @@
 package it.polpetta
 
 import com.github.ajalt.clikt.core.subcommands
+import com.google.inject.Guice
 import it.polpetta.cli.Login
 import it.polpetta.cli.Root
 import it.polpetta.cli.Status
 import it.polpetta.cli.Version
+import it.polpetta.modules.JkkModule
 import it.polpetta.utils.debugThrow
 import it.polpetta.utils.printErrln
 import kotlin.system.exitProcess
+import dev.misfitlabs.kotlinguice4.getInstance
 
 fun main(args: Array<String>) {
+    val injector = Guice.createInjector(JkkModule())
+
     try {
         Root().subcommands(
-            Version(),
-            Login(),
-            Status()
+            injector.getInstance<Version>(),
+            injector.getInstance<Login>(),
+            injector.getInstance<Status>()
         ).main(args)
     }
     catch (e: Exception) {

--- a/src/main/kotlin/it/polpetta/modules/JkkModule.kt
+++ b/src/main/kotlin/it/polpetta/modules/JkkModule.kt
@@ -1,0 +1,7 @@
+package it.polpetta.modules
+
+import dev.misfitlabs.kotlinguice4.KotlinModule
+
+class JkkModule : KotlinModule() {
+    override fun configure() {}
+}

--- a/src/main/kotlin/it/polpetta/utils/JenkinsSession.kt
+++ b/src/main/kotlin/it/polpetta/utils/JenkinsSession.kt
@@ -26,8 +26,8 @@ import it.polpetta.config.Resources
 import java.io.FileNotFoundException
 import java.nio.file.Path
 
-object Jenkins {
-    val session: JenkinsClient?
+class JenkinsSession {
+    var session: JenkinsClient?
 
     init {
         var config: Config? = null
@@ -75,8 +75,10 @@ object Jenkins {
         if (credentials != null) {
             jenkinsBuilder.credentials(credentials)
         }
-
-        return jenkinsBuilder.build()
+        jenkinsBuilder.build().let {
+            session = it;
+            return it;
+        }
     }
 
     /**

--- a/src/test/kotlin/it/polpetta/cli/VersionTest.kt
+++ b/src/test/kotlin/it/polpetta/cli/VersionTest.kt
@@ -18,7 +18,11 @@
 
 package it.polpetta.cli
 
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.stub
 import it.polpetta.config.VersionInfo
+import it.polpetta.utils.JenkinsSession
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -29,8 +33,8 @@ import java.io.PrintStream
 
 
 internal class VersionTest {
-    // TODO We really need to use Guice in order to Inject our version of JenkinsCli (a simulator maybe?)
-    private val version = Version()
+    private val jenkinsSessionMock = mock<JenkinsSession>()
+    private val version = Version(jenkinsSessionMock)
     private val outContent = ByteArrayOutputStream()
     private val errContent = ByteArrayOutputStream()
     private val originalOut = System.out
@@ -50,10 +54,12 @@ internal class VersionTest {
 
     @Tag("it")
     @Test
-    fun `Version formatting should change based on logged in status`() {
-        // FIXME ok so this test is a little dumb. It won't work consistently until Guice is added to the project, and
-        //  we can use dependency injection to push stuff inside the classes we declare. As it is, the test will fail
-        //  if you're currently logged in a Jenkins server.
+    fun `Version formatting before login`()
+    {
+        //Example test, this is not really a command worth testing
+        jenkinsSessionMock.stub {
+            on { retrieveSession() } doReturn null
+        }
         version.run()
         assertEquals("""
             Version: ${VersionInfo.NUMBER}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR aims at adding dependency injection support and mocks to tests.
This is now implemented with Guice and Mockito.
We might also consider [Koin](https://github.com/InsertKoinIO/koin) to perform depencendy injection, which is build natively for Kotlin.
Before merging, we need to discuss which one to use
