### PR TITLE
Using Pacur to generate multiple distros packages.

### DIFF
--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -15,24 +15,22 @@ section="utils"
 priority="optional"
 sources=(
     "https://github.com/Polpetta/jkk/archive/master.tar.gz"
+    "https://downloads.gradle-dn.com/distributions/gradle-6.0.1-bin.zip"
 )
 hashsums=(
     "skip"
+    "d2620b30787c22830bee1b5c6561877d"
 )
-depends:apt=(
+depends:ubuntu=(
     "openjdk-11-jre-headless"
 )
 depends:yum=(
     "java-11-openjdk-headless"
 )
-makedepends=(
-    "git" 
-    "gradle"
-)
 
 build() {
     cd "${srcdir}/${pkgname}-master"
-    gradle install
+    ../gradle-6.0.1/bin/gradle install
 }
 
 package() {

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -28,7 +28,6 @@ hashsums=(
 depends:apt=(
     "openjdk-11-jre-headless"
 )
-
 makedepends:apt=(
     "openjdk-11-jre-headless"
 )
@@ -36,8 +35,14 @@ makedepends:apt=(
 depends:yum=(
     "java-11-openjdk-headless"
 )
-
 makedepends:yum=(
+    "java-11-openjdk-devel"
+)
+
+depends:zypper=(
+    "java-11-openjdk-headless"
+)
+makedepends:zypper=(
     "java-11-openjdk-devel"
 )
 
@@ -49,6 +54,12 @@ build:ubuntu() {
 
 build:fedora() {
     export JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
+    cd "${srcdir}/${pkgname}-master"
+    ../gradle-6.0.1/bin/gradle install
+}
+
+build:opensuse() {
+    export JAVA_HOME=/usr/lib64/jvm/java-11-openjdk/
     cd "${srcdir}/${pkgname}-master"
     ../gradle-6.0.1/bin/gradle install
 }

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -1,13 +1,15 @@
 targets=(
     "centos"
     "fedora"
+    "opensuse"
     "ubuntu"
 )
 pkgname="jkk"
 pkgver="0.1"
 pkgrel="1"
 pkgdesc="A git-like cli for Jenkins written in Kotlin"
-maintainer="jkk team"
+pkgdesclong=("A git-like cli for Jenkins written in Kotlin")
+maintainer="JKK Team"
 url="https://github.com/Polpetta/jkk"
 arch="all"
 license=("GPL3")
@@ -17,18 +19,36 @@ sources=(
     "https://github.com/Polpetta/jkk/archive/master.tar.gz"
     "https://downloads.gradle-dn.com/distributions/gradle-6.0.1-bin.zip"
 )
+
 hashsums=(
     "skip"
     "d2620b30787c22830bee1b5c6561877d"
 )
-depends:ubuntu=(
+
+depends:apt=(
     "openjdk-11-jre-headless"
 )
+
+makedepends:apt=(
+    "openjdk-11-jre-headless"
+)
+
 depends:yum=(
     "java-11-openjdk-headless"
 )
 
-build() {
+makedepends:yum=(
+    "java-11-openjdk-devel"
+)
+
+build:ubuntu() {
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+    cd "${srcdir}/${pkgname}-master"
+    ../gradle-6.0.1/bin/gradle install
+}
+
+build:fedora() {
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
     cd "${srcdir}/${pkgname}-master"
     ../gradle-6.0.1/bin/gradle install
 }

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -1,0 +1,53 @@
+targets=(
+    "centos"
+    "fedora"
+    "ubuntu"
+)
+pkgname="jkk"
+pkgver="0.1"
+pkgrel="1"
+pkgdesc="A git-like cli for Jenkins written in Kotlin"
+maintainer="jkk team"
+url="https://github.com/Polpetta/jkk"
+arch="all"
+license=("GPL3")
+section="utils"
+priority="optional"
+sources=(
+    "https://github.com/Polpetta/jkk/archive/master.tar.gz"
+)
+hashsums=(
+    "skip"
+)
+depends:apt=(
+    "openjdk-11-jre-headless"
+)
+depends:yum=(
+    "java-11-openjdk-headless"
+)
+makedepends=(
+    "git" 
+    "gradle"
+)
+
+build() {
+    cd "${srcdir}/${pkgname}-master"
+    gradle install
+}
+
+package() {
+    cd "${srcdir}/${pkgname}-master"/build/
+    
+    install -Dm 755 install/${pkgname}/bin/jkk \
+        -t "${pkgdir}/usr/share/java/${pkgname}/bin"
+    install -Dm 644 install/${pkgname}/lib/* \
+        -t "${pkgdir}/usr/share/java/${pkgname}/lib"
+    install -d "${pkgdir}/usr/bin"
+    ln -s /usr/share/java/${pkgname}/bin/jkk \
+        "${pkgdir}/usr/bin/jkk"
+    
+    install -Dm 644 ../LICENSE \
+        -t "${pkgdir}/usr/share/licenses/${pkgname}"
+    install -Dm 644 ../README.md \
+        -t "${pkgdir}/usr/share/doc/${pkgname}"
+}

--- a/pacur/README.md
+++ b/pacur/README.md
@@ -1,0 +1,20 @@
+# Build JKK Package
+This script is designed to package JKK for every desidered distro effortlessly.
+
+## Instructions
+- Obtain the Docker image for your target:
+  
+  ```docker pull m0rf30/pacur-<distro>```
+
+- Run the container:
+  
+  ```docker run --entrypoint=/bin/bash -v $(pwd):/pacur -ti m0rf30/pacur-<distro>```
+
+- Build your package from container shell:
+  
+  ```pacur build <distro>```
+
+## Troubleshooting
+If you have problems to test JKK on RPM-based distros, remember to change the JRE with this command:
+  
+  ```alternatives --config java```


### PR DESCRIPTION
With this PR I want to introduce a single file **to rule them all**.
I tested the following distros:
- fedora 30
- opensuse tumbleweed
- ubuntu 18.04
 
OpenSuse Tumbleweed generated package work like a charm, through support added on top of my pacur fork.
This should solve #12. 
A Pacur Tumbleweed image is available:
```docker pull m0rf30/pacur-opensuse:latest```