### PR TITLE
Add Docker image for CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/build
+/jenkins_home
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:6.0-jdk11 as builder
+
+WORKDIR /opt/jkk/
+COPY . /opt/jkk/
+RUN gradle installDist
+
+FROM gcr.io/distroless/java:11-debug
+
+COPY --from=builder /opt/jkk/build/install/ /opt/
+ENTRYPOINT ["sh", "/opt/jkk/bin/jkk"]


### PR DESCRIPTION
This will allow jkk to be used from a Docker container

Example usages:
```
docker build -t test/test .
docker run --rm test/test 
```

It can be useful if you need to perform scheduled commands inside a Kubernetes cluster/Docker Swarm/Mesos/whatever
Additionally I've set-up the automated build from the docker hub, the images will be automatically built here https://hub.docker.com/r/polpetta/jkk. The build has been configured as follows:
* master branch -> latest tag
* git tag (e.g. 1.2) -> 1.2 tag (i.e `polpetta/jkk:1.2`)

Note: at the moment it only supports x86