### PR TITLE
Some useful changes for packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+dist: bionic
 language: java
+services:
+  - docker
 
 jdk:
   - openjdk11
@@ -11,3 +14,16 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+before_install:
+  - docker pull m0rf30/pacur-archlinux
+  - docker pull m0rf30/pacur-fedora-31
+  - docker pull m0rf30/pacur-opensuse
+  - docker pull m0rf30/pacur-ubuntu-eoan
+
+script:
+  - cd pacur
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
   file: ./*.tar.zst
   file: ./sha256sums
   skip_cleanup: true
-  prerelease: true
+  prerelease: false
   on:
     repo: Polpetta/jkk
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,19 @@ script:
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
-  - rm PKGBUILD README.md
+  - for i in $(ls); do sha256sum $i >> sha256sums; done
 deploy:
   provider: releases
   api_key:
     secure: ceDHwwztvMJexkdnLG4h7PFGEZ3K+rpdkzOZ+qnzMzpo+ljeWGEQhHOS9QurLEraa7ncv2c7nMbdTKMorn1afKkOi0l3aT6rHZfZyGbffaXg59M/4wIdm90tdYZYvSE5pg5A0KGk15/oKenqpbSWaQTqbh2xIxDde5lxGs8lmQlOKE9dKaf16ue/swP84dT9xHFDMLR+t6GcRa4a7SZO/jgO4LrdiDhn25kI9lU7KFv1B5sB4+5CRwfq36Gj8J8eu/gHvL5T0z6vrG2HQT0QlvPUiPBS7OIa7lR2VMsVT8I/PO6kjLxduEUcuINVjkEJ5NqsDkMEPSLv+QOcgucz2QmV3rsZPl4+70GyvIc8xzqaaradcubbBxUNJpamCqg1PnFBfpvs5Aok+XsQ42m0Jw0Fv8sxjcVTPFRZGzufJ+txkeOZKK5nncfKEhA7MMpACs3kXQ/xHZIjdoGSSKBiglYMG25FYaB09qCT877EpeXhKziJc5HMWHv3RyYgy8dJDra0gX9hm9LrCU8Hc5nWOks8jIhFgyhHtzXe1248Xh3rQVgd2TtcsofVyLLTyUbBrqAliybiZtl2+licYdA+t5pAkH27E+yXU9Z0D8xuzNjY5UXGRA2tsK9nUzWJkVd5NmE5ceahncUShMRuLn1Q+VhlWW8LqPqCQPcNtoo3lB0=
   file_glob: true
-  file: ./*
+  file: ./*.deb
+  file: ./*.rpm
+  file: ./*.tar.zst
+  file: ./sha256sums
   skip_cleanup: true
   prerelease: true
   on:
     repo: Polpetta/jkk
-    branch: pacur
+    branch: master
     tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,34 @@
 dist: bionic
 language: java
 services:
-  - docker
-
+- docker
 jdk:
-  - openjdk11
-  - oraclejdk11
-
+- openjdk11
+- oraclejdk11
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-
+  - "$HOME/.gradle/caches/"
+  - "$HOME/.gradle/wrapper/"
 before_install:
-  - docker pull m0rf30/pacur-archlinux
-  - docker pull m0rf30/pacur-fedora-31
-  - docker pull m0rf30/pacur-opensuse
-  - docker pull m0rf30/pacur-ubuntu-eoan
-
+- docker pull m0rf30/pacur-archlinux
+- docker pull m0rf30/pacur-fedora-31
+- docker pull m0rf30/pacur-opensuse
+- docker pull m0rf30/pacur-ubuntu-eoan
 script:
-  - mkdir pacur/pkgs
-  - cd pacur/pkgs
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
+- cd pacur
+- docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
+- docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
+- docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
+- docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
+- rm PKGBUILD README.md
+deploy:
+  provider: releases
+  api_key:
+    secure: ceDHwwztvMJexkdnLG4h7PFGEZ3K+rpdkzOZ+qnzMzpo+ljeWGEQhHOS9QurLEraa7ncv2c7nMbdTKMorn1afKkOi0l3aT6rHZfZyGbffaXg59M/4wIdm90tdYZYvSE5pg5A0KGk15/oKenqpbSWaQTqbh2xIxDde5lxGs8lmQlOKE9dKaf16ue/swP84dT9xHFDMLR+t6GcRa4a7SZO/jgO4LrdiDhn25kI9lU7KFv1B5sB4+5CRwfq36Gj8J8eu/gHvL5T0z6vrG2HQT0QlvPUiPBS7OIa7lR2VMsVT8I/PO6kjLxduEUcuINVjkEJ5NqsDkMEPSLv+QOcgucz2QmV3rsZPl4+70GyvIc8xzqaaradcubbBxUNJpamCqg1PnFBfpvs5Aok+XsQ42m0Jw0Fv8sxjcVTPFRZGzufJ+txkeOZKK5nncfKEhA7MMpACs3kXQ/xHZIjdoGSSKBiglYMG25FYaB09qCT877EpeXhKziJc5HMWHv3RyYgy8dJDra0gX9hm9LrCU8Hc5nWOks8jIhFgyhHtzXe1248Xh3rQVgd2TtcsofVyLLTyUbBrqAliybiZtl2+licYdA+t5pAkH27E+yXU9Z0D8xuzNjY5UXGRA2tsK9nUzWJkVd5NmE5ceahncUShMRuLn1Q+VhlWW8LqPqCQPcNtoo3lB0=
+  file: pacur/*
+  on:
+    repo: Polpetta/jkk
+    branch: pacur

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: bionic
 language: java
+env:
+  global:
+    - PACUR_TAG=0.5
 services:
   - docker
 jdk:
@@ -13,17 +16,17 @@ cache:
     - "$HOME/.gradle/caches/"
     - "$HOME/.gradle/wrapper/"
 before_install:
-  - docker pull m0rf30/pacur-archlinux
-  - docker pull m0rf30/pacur-fedora-31
-  - docker pull m0rf30/pacur-opensuse
-  - docker pull m0rf30/pacur-ubuntu-eoan
+  - docker pull m0rf30/pacur-archlinux:$PACUR_TAG
+  - docker pull m0rf30/pacur-fedora-31:$PACUR_TAG
+  - docker pull m0rf30/pacur-opensuse:0:$PACUR_TAG
+  - docker pull m0rf30/pacur-ubuntu-eoan:$PACUR_TAG
 script:
   - cd pacur
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
-  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
-  - for i in $(ls); do sha256sum $i >> sha256sums; done
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux:$PACUR_TAG
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31:$PACUR_TAG
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse:$PACUR_TAG
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan:$PACUR_TAG
+  - for i in $(ls); do sha256sum $i >> SHA256SUMS; done
 deploy:
   provider: releases
   api_key:
@@ -32,7 +35,7 @@ deploy:
   file: ./*.deb
   file: ./*.rpm
   file: ./*.tar.zst
-  file: ./sha256sums
+  file: ./SHA256SUMS
   cleanup: false
   prerelease: false
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: bionic
 language: java
 env:
@@ -18,7 +19,7 @@ cache:
 before_install:
   - docker pull m0rf30/pacur-archlinux:$PACUR_TAG
   - docker pull m0rf30/pacur-fedora-31:$PACUR_TAG
-  - docker pull m0rf30/pacur-opensuse:0:$PACUR_TAG
+  - docker pull m0rf30/pacur-opensuse:$PACUR_TAG
   - docker pull m0rf30/pacur-ubuntu-eoan:$PACUR_TAG
 script:
   - cd pacur
@@ -29,7 +30,7 @@ script:
   - for i in $(ls); do sha256sum $i >> SHA256SUMS; done
 deploy:
   provider: releases
-  api_key:
+  token:
     secure: ceDHwwztvMJexkdnLG4h7PFGEZ3K+rpdkzOZ+qnzMzpo+ljeWGEQhHOS9QurLEraa7ncv2c7nMbdTKMorn1afKkOi0l3aT6rHZfZyGbffaXg59M/4wIdm90tdYZYvSE5pg5A0KGk15/oKenqpbSWaQTqbh2xIxDde5lxGs8lmQlOKE9dKaf16ue/swP84dT9xHFDMLR+t6GcRa4a7SZO/jgO4LrdiDhn25kI9lU7KFv1B5sB4+5CRwfq36Gj8J8eu/gHvL5T0z6vrG2HQT0QlvPUiPBS7OIa7lR2VMsVT8I/PO6kjLxduEUcuINVjkEJ5NqsDkMEPSLv+QOcgucz2QmV3rsZPl4+70GyvIc8xzqaaradcubbBxUNJpamCqg1PnFBfpvs5Aok+XsQ42m0Jw0Fv8sxjcVTPFRZGzufJ+txkeOZKK5nncfKEhA7MMpACs3kXQ/xHZIjdoGSSKBiglYMG25FYaB09qCT877EpeXhKziJc5HMWHv3RyYgy8dJDra0gX9hm9LrCU8Hc5nWOks8jIhFgyhHtzXe1248Xh3rQVgd2TtcsofVyLLTyUbBrqAliybiZtl2+licYdA+t5pAkH27E+yXU9Z0D8xuzNjY5UXGRA2tsK9nUzWJkVd5NmE5ceahncUShMRuLn1Q+VhlWW8LqPqCQPcNtoo3lB0=
   file_glob: true
   file: ./*.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ deploy:
   on:
     repo: Polpetta/jkk
     branch: master
-    tags: false
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,38 @@
 dist: bionic
 language: java
 services:
-- docker
+  - docker
 jdk:
-- openjdk11
-- oraclejdk11
+  - openjdk11
+  - oraclejdk11
 before_cache:
-- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-  - "$HOME/.gradle/caches/"
-  - "$HOME/.gradle/wrapper/"
+    - "$HOME/.gradle/caches/"
+    - "$HOME/.gradle/wrapper/"
 before_install:
-- docker pull m0rf30/pacur-archlinux
-- docker pull m0rf30/pacur-fedora-31
-- docker pull m0rf30/pacur-opensuse
-- docker pull m0rf30/pacur-ubuntu-eoan
+  - docker pull m0rf30/pacur-archlinux
+  - docker pull m0rf30/pacur-fedora-31
+  - docker pull m0rf30/pacur-opensuse
+  - docker pull m0rf30/pacur-ubuntu-eoan
 script:
-- cd pacur
-- docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
-- docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
-- docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
-- docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
-- rm PKGBUILD README.md
+  - cd pacur
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse
+  - docker run -v $(pwd):/pacur -ti m0rf30/pacur-ubuntu-eoan
+  - rm PKGBUILD README.md
 deploy:
   provider: releases
   api_key:
     secure: ceDHwwztvMJexkdnLG4h7PFGEZ3K+rpdkzOZ+qnzMzpo+ljeWGEQhHOS9QurLEraa7ncv2c7nMbdTKMorn1afKkOi0l3aT6rHZfZyGbffaXg59M/4wIdm90tdYZYvSE5pg5A0KGk15/oKenqpbSWaQTqbh2xIxDde5lxGs8lmQlOKE9dKaf16ue/swP84dT9xHFDMLR+t6GcRa4a7SZO/jgO4LrdiDhn25kI9lU7KFv1B5sB4+5CRwfq36Gj8J8eu/gHvL5T0z6vrG2HQT0QlvPUiPBS7OIa7lR2VMsVT8I/PO6kjLxduEUcuINVjkEJ5NqsDkMEPSLv+QOcgucz2QmV3rsZPl4+70GyvIc8xzqaaradcubbBxUNJpamCqg1PnFBfpvs5Aok+XsQ42m0Jw0Fv8sxjcVTPFRZGzufJ+txkeOZKK5nncfKEhA7MMpACs3kXQ/xHZIjdoGSSKBiglYMG25FYaB09qCT877EpeXhKziJc5HMWHv3RyYgy8dJDra0gX9hm9LrCU8Hc5nWOks8jIhFgyhHtzXe1248Xh3rQVgd2TtcsofVyLLTyUbBrqAliybiZtl2+licYdA+t5pAkH27E+yXU9Z0D8xuzNjY5UXGRA2tsK9nUzWJkVd5NmE5ceahncUShMRuLn1Q+VhlWW8LqPqCQPcNtoo3lB0=
-  file: pacur/*
+  file_glob: true
+  file: ./*
+  skip_cleanup: true
+  prerelease: true
   on:
     repo: Polpetta/jkk
     branch: pacur
+    tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ deploy:
   file: ./*.rpm
   file: ./*.tar.zst
   file: ./sha256sums
-  skip_cleanup: true
+  cleanup: false
   prerelease: false
   on:
     repo: Polpetta/jkk

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_install:
   - docker pull m0rf30/pacur-ubuntu-eoan
 
 script:
-  - cd pacur
+  - mkdir pacur/pkgs
+  - cd pacur/pkgs
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-archlinux
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-fedora-31
   - docker run -v $(pwd):/pacur -ti m0rf30/pacur-opensuse

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ smooth this task by integrating the build information directly in the developer 
 If you want to get in touch with the developers or if you have any questions you can find us in our [official Discord server](https://discord.gg/KkYr4Zb)!
 
 ## Installing
+
+### Install Pre-built Packages
+The easiest way to run this project is to download a pre-built binary. You can find binaries of our latest release [here](https://github.com/polpetta/jkk/releases/).
+At the moment it supports:
+- Arch Linux
+- Fedora 31
+- openSUSE Tumbleweed
+- Ubuntu 19.10
+
 ### From source
 The project is configured using Gradle. It comes with the "application" plugin that allows to easily generate a
 ready-to-use jar, wrapped up by a shell script.
@@ -31,7 +40,6 @@ If you're lucky enough to use Arch Linux, someone has an AUR package just for yo
 - `makepkg -si`
 
 ## Documentation
-
 If you are searching for code documentation, you can find it in the source files 😉. If you are searching for user documentation instead, you can find it [in our wiki](https://github.com/Polpetta/jkk/wiki). No luck? Open an issue and tell us what is missing!
 
 ## License

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -37,6 +37,7 @@ depends:pacman=(
 )
 makedepends:pacman=(
     "gradle"
+    "unzip"
 )
 
 depends:yum=(

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -1,5 +1,5 @@
 targets=(
-    "centos"
+    "archlinux"
     "fedora"
     "opensuse"
     "ubuntu"
@@ -32,6 +32,13 @@ makedepends:apt=(
     "openjdk-11-jre-headless"
 )
 
+depends:pacman=(
+    "jre11-openjdk-headless"
+)
+makedepends:pacman=(
+    "gradle"
+)
+
 depends:yum=(
     "java-11-openjdk-headless"
 )
@@ -46,10 +53,10 @@ makedepends:zypper=(
     "java-11-openjdk-devel"
 )
 
-build:ubuntu() {
-    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+build:archlinux() {
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
     cd "${srcdir}/${pkgname}-master"
-    ../gradle-6.0.1/bin/gradle install
+    gradle install
 }
 
 build:fedora() {
@@ -60,6 +67,12 @@ build:fedora() {
 
 build:opensuse() {
     export JAVA_HOME=/usr/lib64/jvm/java-11-openjdk/
+    cd "${srcdir}/${pkgname}-master"
+    ../gradle-6.0.1/bin/gradle install
+}
+
+build:ubuntu() {
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
     cd "${srcdir}/${pkgname}-master"
     ../gradle-6.0.1/bin/gradle install
 }

--- a/pacur/PKGBUILD
+++ b/pacur/PKGBUILD
@@ -19,6 +19,7 @@ sources=(
     "https://github.com/Polpetta/jkk/archive/master.tar.gz"
     "https://downloads.gradle-dn.com/distributions/gradle-6.0.1-bin.zip"
 )
+sources:archlinux=("https://github.com/Polpetta/jkk/archive/master.tar.gz")
 
 hashsums=(
     "skip"


### PR DESCRIPTION
- Added binary packages generation for
  - Arch Linux
  - Fedora 31
  - openSUSE Tumbleweed
  - Ubuntu 19.10
- Added some details on prebuilt binaries usage
- Travis use latest Ubuntu Bionic agent
- Travis now upload artifacts and sha256sums 
- Travis now build new .pkg.tar.zst Arch Linux packages (+1300% in decompression and installation phase). New extension will be available on next commits.
- Gradle binary is not downloaded during Arch Linux packaging, cause it's in official repos