### PR TITLE
Fix #25 - Fat JAR task is now available for fat builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM gradle:6.0-jdk11 as builder
 
 WORKDIR /opt/jkk/
 COPY . /opt/jkk/
-RUN gradle jar
+RUN gradle standalone
 
-FROM gcr.io/distroless/java:11-debug
+FROM gcr.io/distroless/java:11
 
 COPY --from=builder /opt/jkk/build/libs/*.jar /opt/jkk/jkk.jar
 ENTRYPOINT ["java", "--add-opens=java.base/java.lang=ALL-UNNAMED", "-jar", "/opt/jkk/jkk.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -69,14 +69,21 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
-jar {
+task standalone(type: Jar) {
+    dependsOn configurations.runtimeClasspath
+    archiveClassifier = 'standalone'
+    from sourceSets.main.output
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    from(configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }) {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
     manifest {
         attributes 'Implementation-Title': 'JKK: A git-like cli for Jenkins written in Kotlin',
-                   'Main-Class': 'it.polpetta.Cli'
+                'Built-By': System.getProperty('user.name'),
+                'Built-Date': new Date(),
+                'Built-JDK': System.getProperty('java.version'),
+                'Main-Class': 'it.polpetta.Cli'
     }
-    from {
-        configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }


### PR DESCRIPTION
* This fixes Docker container image that now works flawlessly
* Fix the Jar problem with doubled size when building the JAR in a
  normal way

Closes #25 